### PR TITLE
Add denpencies required by JavaFX JUnit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
+    testImplementation group: 'org.testfx', name: 'testfx-junit5', version: '4.0.18'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }


### PR DESCRIPTION
testfx-junit5, version: 4.0.18, required for handling lifecycle of JavaFX under testing environment.
hamcrest, version: 2.2, required by testfx-junit5.