### PR TITLE
Disambiguate courses in tutorial and lab tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -113,8 +113,12 @@ fast, Doritus can get your contact management tasks done faster than traditional
 - Special tags: these tags follow a specific format:
     - Tutorial groups: begins with `tut:`, followed by an optional uppercase letter and maximally 2 digits (e.g.
       `tut:A11`, `tut:17`, `tut:2`)
+        - They can optionally be associated with **one** valid `course` separated by a dash (`-`). (e.g. `tut:A11-CS2103T`)
+        - The associated `course` tag does not have to already be assigned to the given person
     - Lab groups: begins with `lab:`, followed by an optional uppercase letter and maximally 2 digits (e.g. `lab:A11`,
       `lab:17`, `lab:2`)
+        - They can optionally be associated with **one** valid `course` separated by a dash (`-`). (e.g. `lab:A11-CS2103T`)
+        - The associated `course` tag does not have to already be assigned to the given person
     - Course: begins with `course:`, followed 2-4 uppercase letters, proceeded by 4 digits and an optional uppercase
       suffix letter (e.g. `course:CS2103`, `course:CS2103T`, `course:GESS1000T`)
 
@@ -356,6 +360,8 @@ Appends tags to an existing person, without having to respecify all existing tag
 
 * `tag-add 1 t/needsHelp t/course:CS2103T t/tut:10` - Adds tags to indicate that the first visible person is in the
   course CS2103T who resides in tutorial group 10 and needs help
+* `tag-add 1 t/course:CS2103T t/course:CS1231S t/tut:10-CS2103T` - Adds tags to indicate that the first visible person is in the
+  course CS2103T and CS1231S, specifically in tutorial group 10 of the course CS2103T
 
 ### Locating persons by name/tag: `find`
 

--- a/src/main/java/seedu/address/model/tag/restricted/CourseTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/CourseTagSchema.java
@@ -11,8 +11,8 @@ package seedu.address.model.tag.restricted;
 public class CourseTagSchema extends RegexTagSchema {
     public static final String VARIANT = "course";
     public static final String TAG_PATTERN = "[A-Z]{2,4}\\d{4}[A-Z]?";
-    public static final String MESSAGE_CONSTRAINTS = "Course code expects format: 2-4 uppercase letters "
-            + "followed by 4 numbers, and an optional uppercase suffix. Valid course (example): 'CS2103T', 'MA1521', 'GESS1000T'";
+    public static final String MESSAGE_CONSTRAINTS = "Course code expects format: 2-4 uppercase letters followed by "
+            + "4 numbers, and an optional uppercase suffix. Valid course (example): 'CS2103T', 'MA1521', 'GESS1000T'";
 
     /**
      * Constructs a {@code CourseTagSchema}.

--- a/src/main/java/seedu/address/model/tag/restricted/CourseTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/CourseTagSchema.java
@@ -12,7 +12,7 @@ public class CourseTagSchema extends RegexTagSchema {
     public static final String VARIANT = "course";
     public static final String TAG_PATTERN = "[A-Z]{2,4}\\d{4}[A-Z]?";
     public static final String MESSAGE_CONSTRAINTS = "Course code expects format: 2-4 uppercase letters "
-            + "followed by 4 numbers, and an optional uppercase suffix. Valid course: 'CS2103T', 'MA1521', 'GESS1000T'";
+            + "followed by 4 numbers, and an optional uppercase suffix. Valid course (example): 'CS2103T', 'MA1521', 'GESS1000T'";
 
     /**
      * Constructs a {@code CourseTagSchema}.

--- a/src/main/java/seedu/address/model/tag/restricted/CourseTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/CourseTagSchema.java
@@ -11,8 +11,8 @@ package seedu.address.model.tag.restricted;
 public class CourseTagSchema extends RegexTagSchema {
     public static final String VARIANT = "course";
     public static final String TAG_PATTERN = "[A-Z]{2,4}\\d{4}[A-Z]?";
-    public static final String MESSAGE_CONSTRAINTS = "CourseTagSchema tag expects format of 2-4 uppercase letters "
-            + "followed by 4 numbers, and an optional uppercase suffix. Valid: 'CS2103T', 'MA1521', 'GESS1000T'";
+    public static final String MESSAGE_CONSTRAINTS = "Course code expects format: 2-4 uppercase letters "
+            + "followed by 4 numbers, and an optional uppercase suffix. Valid course: 'CS2103T', 'MA1521', 'GESS1000T'";
 
     /**
      * Constructs a {@code CourseTagSchema}.

--- a/src/main/java/seedu/address/model/tag/restricted/LabTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/LabTagSchema.java
@@ -14,7 +14,8 @@ public class LabTagSchema extends RegexTagSchema {
     public static final String TAG_PATTERN = "[A-Z]?\\d{1,2}(-" + CourseTagSchema.TAG_PATTERN + ")?";
     public static final String MESSAGE_CONSTRAINTS = "Lab tag expects format of an optional uppercase letter "
             + "followed by maximum 2 numbers.\nOPTIONAL: an associated course is attachable at the end "
-            + "with a dash (-). " + CourseTagSchema.MESSAGE_CONSTRAINTS + "\nValid lab: 'D24-CS2103T' and '8'";
+            + "with a dash (-). " + CourseTagSchema.MESSAGE_CONSTRAINTS + "\n"
+            + "Valid lab: 'D24-CS2103T' and '8'";
 
     /**
      * Constructs a {@code LabTagSchema}.

--- a/src/main/java/seedu/address/model/tag/restricted/LabTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/LabTagSchema.java
@@ -15,7 +15,7 @@ public class LabTagSchema extends RegexTagSchema {
     public static final String MESSAGE_CONSTRAINTS = "Lab tag expects format of an optional uppercase letter "
             + "followed by maximum 2 numbers.\nOPTIONAL: an associated course is attachable at the end "
             + "with a dash (-). " + CourseTagSchema.MESSAGE_CONSTRAINTS + "\n"
-            + "Valid lab: 'D24-CS2103T' and '8'";
+            + "Valid lab (example): 'D24-CS2103T' and '8'";
 
     /**
      * Constructs a {@code LabTagSchema}.

--- a/src/main/java/seedu/address/model/tag/restricted/LabTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/LabTagSchema.java
@@ -11,9 +11,10 @@ package seedu.address.model.tag.restricted;
  */
 public class LabTagSchema extends RegexTagSchema {
     public static final String VARIANT = "lab";
-    public static final String TAG_PATTERN = "[A-Z]?\\d{1,2}";
+    public static final String TAG_PATTERN = "[A-Z]?\\d{1,2}(-" + CourseTagSchema.TAG_PATTERN + ")?";
     public static final String MESSAGE_CONSTRAINTS = "Lab tag expects format of an optional uppercase letter "
-            + "followed by maximum 2 numbers. Valid: 'D24' and '8'";
+            + "followed by maximum 2 numbers.\nOPTIONAL: an associated course is attachable at the end "
+            + "with a dash (-). " + CourseTagSchema.MESSAGE_CONSTRAINTS + "\nValid lab: 'D24-CS2103T' and '8'";
 
     /**
      * Constructs a {@code LabTagSchema}.

--- a/src/main/java/seedu/address/model/tag/restricted/TutorialTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/TutorialTagSchema.java
@@ -12,7 +12,8 @@ public class TutorialTagSchema extends RegexTagSchema {
     public static final String TAG_PATTERN = "[A-Z]?\\d{1,2}(-" + CourseTagSchema.TAG_PATTERN + ")?";
     public static final String MESSAGE_CONSTRAINTS = "Tutorial tag expects format of an optional uppercase letter "
             + "followed by maximum 2 numbers.\nOPTIONAL: an associated course is attachable at the end "
-            + "with a dash (-). " + CourseTagSchema.MESSAGE_CONSTRAINTS + "\nValid tutorial: 'D24-CS2103T' and '8'";
+            + "with a dash (-). " + CourseTagSchema.MESSAGE_CONSTRAINTS + "\n"
+            + "Valid tutorial: 'D24-CS2103T' and '8'";
 
     /**
      * Constructs a {@code TutorialTagSchema}.

--- a/src/main/java/seedu/address/model/tag/restricted/TutorialTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/TutorialTagSchema.java
@@ -13,7 +13,7 @@ public class TutorialTagSchema extends RegexTagSchema {
     public static final String MESSAGE_CONSTRAINTS = "Tutorial tag expects format of an optional uppercase letter "
             + "followed by maximum 2 numbers.\nOPTIONAL: an associated course is attachable at the end "
             + "with a dash (-). " + CourseTagSchema.MESSAGE_CONSTRAINTS + "\n"
-            + "Valid tutorial: 'D24-CS2103T' and '8'";
+            + "Valid tutorial (example): 'D24-CS2103T' and '8'";
 
     /**
      * Constructs a {@code TutorialTagSchema}.

--- a/src/main/java/seedu/address/model/tag/restricted/TutorialTagSchema.java
+++ b/src/main/java/seedu/address/model/tag/restricted/TutorialTagSchema.java
@@ -9,9 +9,10 @@ package seedu.address.model.tag.restricted;
  */
 public class TutorialTagSchema extends RegexTagSchema {
     public static final String VARIANT = "tut";
-    public static final String TAG_PATTERN = "[A-Z]?\\d{1,2}";
+    public static final String TAG_PATTERN = "[A-Z]?\\d{1,2}(-" + CourseTagSchema.TAG_PATTERN + ")?";
     public static final String MESSAGE_CONSTRAINTS = "Tutorial tag expects format of an optional uppercase letter "
-            + "followed by maximum 2 numbers. Valid: 'D24' and '8'";
+            + "followed by maximum 2 numbers.\nOPTIONAL: an associated course is attachable at the end "
+            + "with a dash (-). " + CourseTagSchema.MESSAGE_CONSTRAINTS + "\nValid tutorial: 'D24-CS2103T' and '8'";
 
     /**
      * Constructs a {@code TutorialTagSchema}.

--- a/src/test/java/seedu/address/model/tag/restricted/LabTagSchemaTest.java
+++ b/src/test/java/seedu/address/model/tag/restricted/LabTagSchemaTest.java
@@ -33,6 +33,19 @@ public class LabTagSchemaTest {
     }
 
     @Test
+    public void testValidTag_optionalCourseSuffix() {
+        assertTrue(schema.isTagValid(VALID_LAB_TAG + "-" + CourseTagSchemaTest.VALID_COURSE_TAG));
+    }
+
+    @Test
+    public void testInvalidTag_optionalCourseSuffix() {
+        assertFalse(schema.isTagValid(CourseTagSchemaTest.VALID_COURSE_TAG));
+        assertFalse(schema.isTagValid("-" + CourseTagSchemaTest.VALID_COURSE_TAG));
+        assertFalse(schema.isTagValid(VALID_LAB_TAG + "-"));
+        assertFalse(schema.isTagValid(VALID_LAB_TAG + "-" + CourseTagSchemaTest.INVALID_COURSE_TAG));
+    }
+
+    @Test
     public void testGetConstraintViolationMessage() {
         assertEquals(LabTagSchema.MESSAGE_CONSTRAINTS, schema.getConstraintViolationMessage());
     }

--- a/src/test/java/seedu/address/model/tag/restricted/TutorialTagSchemaTest.java
+++ b/src/test/java/seedu/address/model/tag/restricted/TutorialTagSchemaTest.java
@@ -32,6 +32,19 @@ public class TutorialTagSchemaTest {
     }
 
     @Test
+    public void testValidTag_optionalCourseSuffix() {
+        assertTrue(schema.isTagValid(VALID_TUTORIAL_TAG + "-" + CourseTagSchemaTest.VALID_COURSE_TAG));
+    }
+
+    @Test
+    public void testInvalidTag_optionalCourseSuffix() {
+        assertFalse(schema.isTagValid(CourseTagSchemaTest.VALID_COURSE_TAG));
+        assertFalse(schema.isTagValid("-" + CourseTagSchemaTest.VALID_COURSE_TAG));
+        assertFalse(schema.isTagValid(VALID_TUTORIAL_TAG + "-"));
+        assertFalse(schema.isTagValid(VALID_TUTORIAL_TAG + "-" + CourseTagSchemaTest.INVALID_COURSE_TAG));
+    }
+
+    @Test
     public void testGetConstraintViolationMessage() {
         assertEquals(TutorialTagSchema.MESSAGE_CONSTRAINTS, schema.getConstraintViolationMessage());
     }


### PR DESCRIPTION
Fixes #278.

Tutorial and lab tags can now contain an optional `-` at the end with a course (e.g. `tut:12-CS2103`).
This is done so that a specific tutorial/lab group can be associated with a corresponding course (if required by user, to be unambiguous if person is in multiple courses)

We still allow tags like `tut:12`. For example, if a TA only teaches a single course, they might choose to forgo the course tag altogether for convenience.

An existing course tag is not enforced if this suffix is specified. This allows maximum flexibility on how a user chooses to utilise the system.

In summary, a tag like `tut:12-CS2103` and `tut:12` can exist at the same time since a person can be teaching multiple tutorial groups with the same number. If the user chooses to do this, they can disambiguate by their own decided convention (I mainly teach CS1101S so the one without a course tag is the main one I'm looking at (faster to identify this way), and I currently help out tut group 12 (CS2103) on the side, etc.)