### PR TITLE
Allow case insensitive Tag + allow update of casing in tag-add

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -110,6 +110,7 @@ fast, Doritus can get your contact management tasks done faster than traditional
 ### Types of tags
 
 - General purpose tags: Alphanumeric characters only (e.g. `examDuty`)
+    - Case-insensitive (e.g. `examDuty` and `examduty` are treated as equivalent tags)
 - Special tags: these tags follow a specific format:
     - Tutorial groups: begins with `tut:`, followed by an optional uppercase letter and maximally 2 digits (e.g.
       `tut:A11`, `tut:17`, `tut:2`)
@@ -350,7 +351,8 @@ Appends tags to an existing person, without having to respecify all existing tag
 
 * Unlike the `edit` command, `tag-add` will not override existing tags. Instead, all tags specified will be added to the
   person's list of tags.
-* A warning will be generated if any of the tags already exist (but command will still succeed)
+* A warning will be generated if any of the tags already exist (the command will update the existing entry with the new tag)
+* If multiple duplicate tags are present, the first instance will be picked (e.g. `tag-add 1 t/theTag t/thetag`, `theTag` is used)
 
 **Examples:**
 

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -35,7 +35,7 @@ public class AddTagCommand extends Command {
     //@formatter:on
 
     public static final String MESSAGE_ADD_SUCCESS = "Successfully added tag(s) to Person: %1$s";
-    public static final String MESSAGE_WARNING_DUPLICATE = "WARNING, the following tags were ignored "
+    public static final String MESSAGE_WARNING_DUPLICATE = "WARNING, the following tags were updated "
             + "as they already exist: %1$s";
 
     private Index targetPersonIndex;
@@ -108,7 +108,7 @@ public class AddTagCommand extends Command {
 
     /**
      * Creates a new set of tags by combining the existing tags with the new tags to
-     * be added.
+     * be added. Any duplicate tags will be updated to the newer version.
      *
      * @param existing The set of tags currently assigned to the existing person.
      * @return A new set containing all tags from both existing and new tags, with
@@ -116,6 +116,7 @@ public class AddTagCommand extends Command {
      */
     private Set<AbstractTag> appendTags(Set<AbstractTag> existing) {
         var newTags = new HashSet<>(existing);
+        newTags.removeAll(tagsToAdd);
         newTags.addAll(tagsToAdd);
         return newTags;
     }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -2,8 +2,11 @@ package seedu.address.model.tag;
 
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Objects;
+
 /**
  * Represents a Tag in the address book.
+ * Tags are case-insensitive (i.e. tag and Tag are equivalent)
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag extends AbstractTag {
@@ -34,6 +37,18 @@ public class Tag extends AbstractTag {
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        return Objects.hash(tagName.toLowerCase(), getTagType());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Tag otherTag)) {
+            return false;
+        }
+        return tagName.equalsIgnoreCase(otherTag.tagName) && getTagType() == otherTag.getTagType();
     }
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -49,6 +49,6 @@ public class Tag extends AbstractTag {
         if (!(other instanceof Tag otherTag)) {
             return false;
         }
-        return tagName.equalsIgnoreCase(otherTag.tagName) && getTagType() == otherTag.getTagType();
+        return tagName.toLowerCase().equals(otherTag.tagName.toLowerCase()) && getTagType() == otherTag.getTagType();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
@@ -107,6 +107,43 @@ public class AddTagCommandTest {
     }
 
     @Test
+    public void duplicateTagUpdated() {
+        String initial = "abc123";
+        String updated = "ABC123";
+        HashSet<AbstractTag> initialTag = new HashSet<>(List.of(new Tag(initial)));
+        HashSet<AbstractTag> updatedTag = new HashSet<>(List.of(new Tag(updated)));
+
+        // set this person to have only one tag: "abc123"
+        Person personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        model.setPerson(personToEdit, personToEdit.cloneInto(p -> {
+            p.setTags(initialTag);
+        }));
+
+        // ensure updated version
+        personToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        AddTagCommand addTagCommand = new AddTagCommand(INDEX_FIRST_PERSON, updatedTag);
+
+        Person editedPerson = personToEdit.cloneInto(p -> {
+            p.setTags(updatedTag);
+        });
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(personToEdit, editedPerson);
+
+        assertCommandSuccessModelOnly(addTagCommand, model, expectedModel);
+
+        // now the person should have that tag updated "abc123" -> "ABC123" (note the casing)
+        Tag finalUpdatedTag = (Tag) expectedModel.getFilteredPersonList()
+                .get(INDEX_FIRST_PERSON.getZeroBased())
+                .getTags()
+                .stream()
+                .findFirst()
+                .get();
+        assertEquals(finalUpdatedTag.getTagName(), updated);
+    }
+
+    @Test
     public void addTag_invalidIndex_success() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
 

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,5 +1,7 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,15 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+    }
+
+    @Test
+    public void caseInsensitivity_acceptable() {
+        String cased = "theTag";
+        Tag casedTag = new Tag(cased);
+        Tag uncasedTag = new Tag(cased.toLowerCase());
+        assertEquals(casedTag, uncasedTag);
+        assertTrue(casedTag.hashCode() == uncasedTag.hashCode());
     }
 
 }

--- a/src/test/java/seedu/address/storage/CsvExporterTest.java
+++ b/src/test/java/seedu/address/storage/CsvExporterTest.java
@@ -59,7 +59,12 @@ public class CsvExporterTest {
                 .build();
 
         String csv = CsvExporter.convertToCsv(student);
-        assertEquals("Student,\"Alice Smith\",81234567,alicesmith,alice@example.com,cs2103;tutee", csv);
+
+        // due to the nature of the hashset ordering of tags, either outcome is possible
+        // test for both cases to resolve flaky tests
+        String possibleCsv1 = "Student,\"Alice Smith\",81234567,alicesmith,alice@example.com,cs2103;tutee";
+        String possibleCsv2 = "Student,\"Alice Smith\",81234567,alicesmith,alice@example.com,tutee;cs2103";
+        assertTrue(csv.equals(possibleCsv1) || csv.equals(possibleCsv2));
     }
 
     @Test


### PR DESCRIPTION
Upon discussion, regular tags should be case insensitive (i.e. `tag` and `Tag` are equivalent).
RestrictedTag will remain as is since they are specifically designed to be a restrictive, standardised format.

This should aid implementation in the search feature too.